### PR TITLE
preg_split() use is updated to be compatible with PHP8.1+

### DIFF
--- a/src/CodepointConverter/Utf8.php
+++ b/src/CodepointConverter/Utf8.php
@@ -129,7 +129,7 @@ class Utf8 extends CodepointConverter
         } else {
             $result = null;
             if (function_exists('preg_split')) {
-                $characters = @preg_split('//u', (string) $string, null, PREG_SPLIT_NO_EMPTY);
+                $characters = @preg_split('//u', (string) $string, -1, PREG_SPLIT_NO_EMPTY);
                 if (is_array($characters) && implode('', $characters) === $string) {
                     for ($i = 0, $n = count($characters), $ok = true; $ok && $i < $n; ++$i) {
                         $character = $characters[$i];


### PR DESCRIPTION
As of PHP 8.1 passing `null` value as "no limit" for `$limit` argument triggers deprecation warning. `-1` or `0` are the only allowed values according to [documentation](https://www.php.net/manual/en/function.preg-split.php#refsect1-function.preg-split-parameters)

Can be tested on 3v4l: 
 - [with `null`](https://3v4l.org/c6Auh#veol)
 - [with `-1`](https://3v4l.org/CUM1O#veol)