### PR TITLE
Prevent implicit conversion warning

### DIFF
--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -237,13 +237,7 @@ class Punycode
                             }
                             $code = $t + (($q - $t) % (self::BOOTSTRING_BASE - $t));
                             $result .= $dictionary[$code];
-                            if (version_compare(PHP_VERSION, '7.0') >= 0) {
-                                /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
-                                // This prevents warning 'Deprecated: Implicit conversion from float
-                                $q = intdiv(($q - $t), (self::BOOTSTRING_BASE - $t));
-                            } else {
-                                $q = ($q - $t) / (self::BOOTSTRING_BASE - $t);
-                            }
+                            $q = intval(($q - $t) / (self::BOOTSTRING_BASE - $t));
                         }
                         $result .= $dictionary[(int) $q];
                         $bias = self::adapt($delta, $h + 1, ($h === $numBasicCodepoints));

--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -237,7 +237,13 @@ class Punycode
                             }
                             $code = $t + (($q - $t) % (self::BOOTSTRING_BASE - $t));
                             $result .= $dictionary[$code];
-                            $q = ($q - $t) / (self::BOOTSTRING_BASE - $t);
+                            if (version_compare(PHP_VERSION, '7.0') >= 0) {
+                                /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
+                                // This prevents warning 'Deprecated: Implicit conversion from float 10.457142857142857 to int loses precision'
+                                $q = intdiv(($q - $t), (self::BOOTSTRING_BASE - $t));
+                            } else {
+                                $q = ($q - $t) / (self::BOOTSTRING_BASE - $t);
+                            }
                         }
                         $result .= $dictionary[(int) $q];
                         $bias = self::adapt($delta, $h + 1, ($h === $numBasicCodepoints));

--- a/src/Punycode.php
+++ b/src/Punycode.php
@@ -239,7 +239,7 @@ class Punycode
                             $result .= $dictionary[$code];
                             if (version_compare(PHP_VERSION, '7.0') >= 0) {
                                 /** @noinspection PhpElementIsNotAvailableInCurrentPhpVersionInspection */
-                                // This prevents warning 'Deprecated: Implicit conversion from float 10.457142857142857 to int loses precision'
+                                // This prevents warning 'Deprecated: Implicit conversion from float
                                 $q = intdiv(($q - $t), (self::BOOTSTRING_BASE - $t));
                             } else {
                                 $q = ($q - $t) / (self::BOOTSTRING_BASE - $t);


### PR DESCRIPTION
I encountered the warning along the lines of `Deprecated: Implicit conversion from float 10.457142857142857 to int loses precision` running on PHP 8.1